### PR TITLE
Deploy landing page to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'index.html'
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages (auto-enable if needed)
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that deploys the static landing page (`index.html` + `docs/`) to **GitHub Pages**. Direct Pages/API enablement isn't possible from the current environment (proxy blocks repository-settings writes), so this does it from CI instead — the workflow runs on GitHub's runners using the built-in token.

## How it works

- `actions/configure-pages@v5` with `enablement: true` — turns Pages on automatically if it isn't already.
- `actions/upload-pages-artifact@v3` — uploads the repo root (so `index.html` and `docs/ML_project.pdf` are served).
- `actions/deploy-pages@v4` — publishes to the `github-pages` environment.

Triggers on pushes to `main` that touch the site files, plus manual `workflow_dispatch`. Once this merges, the workflow runs and the site should be live at `https://scaliaven.github.io/ML_contest/`.

## Note

If org policy prevents Actions from enabling Pages, the `configure-pages` step will fail — in that case Pages just needs to be turned on once manually (Settings → Pages → Source: GitHub Actions) and the workflow will succeed on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rkob8y4SwdtKZLSeKNXNsg)_